### PR TITLE
feat: Improve the desktop file

### DIFF
--- a/data/desktop.in
+++ b/data/desktop.in
@@ -1,10 +1,20 @@
 [Desktop Entry]
-Name=@PACKAGE_NAME@
-GenericName=@GENERIC_NAME@
-Exec=@MAIN_EXECUTEBLE_NAME@
-Icon=@PACKAGE_NAME@
 Type=Application
-Comment=@GENERIC_NAME@
+
+Name=@GENERIC_NAME@
+GenericName=Software-defined-instrument control app
+GenericName[cs]=Aplikace pro ovládání softwarově definovaných přístrojů
+Icon=@PACKAGE_NAME@
+
+Exec=@MAIN_EXECUTEBLE_NAME@
 Terminal=false
-Categories=Office;Education;DataVisualization;
-Keywords=electronics;education;
+StartupWMClass=@MAIN_EXECUTEBLE_NAME@
+StartupNotify=true
+
+Comment=Interact with F0-Lab and other SDI lab instruments
+Comment[cz]=Pracujte s F0-Lab a dalšími SDI laboratorními přístroji
+
+Categories=Education;Electronics;DataVisualization;
+
+Keywords=oscilloscope;voltmeter;generator
+Keywords[cs]=osciloskop;voltmetr;generátor


### PR DESCRIPTION
This integrates the changes made in https://github.com/adamberlinger/zero_elabviewer/pull/3 .

~~It also removes the `GenericName=` key - I think that repeating the program name goes against the spirit of GenericName. I don't know a good replacement for now (options such as "Software Defined Instrument Viewer" seem too long or too vague to me).~~